### PR TITLE
homework02

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,17 +2,18 @@
 #include <cstdio>
 #include <memory>
 
+template <typename T>
 struct Node {
     // 这两个指针会造成什么问题？请修复
     std::unique_ptr<Node> next;
     Node* prev;
     // 如果能改成 unique_ptr 就更好了!
 
-    int value;
+    T value;
 
-    explicit Node(int value) : value(value), prev(nullptr) {}  // 有什么可以改进的？
+    explicit Node(T value) : value(value), prev(nullptr) {}  // 有什么可以改进的？
 
-    void insert(int value) {
+    void insert(T value) {
         auto node = std::make_unique<Node>(value);
         node->value = value;
         node->next = std::move(next);
@@ -37,8 +38,11 @@ struct Node {
     }
 };
 
+template <typename T>
 struct List {
-    std::unique_ptr<Node> head;
+    typedef Node<T> NodeT;
+
+    std::unique_ptr<NodeT> head;
 
     List() = default;
 
@@ -64,25 +68,25 @@ struct List {
     List(List &&) = default;
     List &operator=(List &&) = default;
 
-    Node *front() const {
+    NodeT *front() const {
         return head.get();
     }
 
-    int pop_front() {
-        int ret = head->value;
+    T pop_front() {
+        T ret = head->value;
         head = std::move(head->next);
         return ret;
     }
 
-    void push_front(int value) {
-        auto node = std::make_unique<Node>(value);
+    void push_front(T value) {
+        auto node = std::make_unique<NodeT>(value);
         if (head)
             head->prev = node.get();
         node->next = std::move(head);
         head = std::move(node);
     }
 
-    Node *at(size_t index) const {
+    NodeT *at(size_t index) const {
         auto curr = front();
         for (size_t i = 0; i < index; i++) {
             curr = curr->next.get();
@@ -91,7 +95,8 @@ struct List {
     }
 };
 
-void print(const List& lst) {  // 有什么值得改进的？
+template <typename T>
+void print(const List<T>& lst) {  // 有什么值得改进的？
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);
@@ -100,7 +105,7 @@ void print(const List& lst) {  // 有什么值得改进的？
 }
 
 int main() {
-    List a;
+    List<int> a;
 
     a.push_front(7);
     a.push_front(5);

--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,6 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include <memory>
-#include <stdexcept>
 
 struct Node {
     // 这两个指针会造成什么问题？请修复
@@ -45,12 +44,12 @@ struct List {
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        // head = other.head;  这是浅拷贝！
+        // head = other.head; // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
 
         auto curr=other.front();
         // tail insertion step 1. go to the tail
-        while (curr->next.get()) {
+        while (curr->next) {
             curr = curr->next.get();
         }
         // tail insertion step 2. traverse from tail to head
@@ -60,13 +59,12 @@ struct List {
         }
     }
 
-    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？ 
+    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
 
     List(List &&) = default;
     List &operator=(List &&) = default;
 
     Node *front() const {
-        
         return head.get();
     }
 
@@ -78,7 +76,7 @@ struct List {
 
     void push_front(int value) {
         auto node = std::make_unique<Node>(value);
-        if (head.get())
+        if (head)
             head->prev = node.get();
         node->next = std::move(head);
         head = std::move(node);

--- a/main.cpp
+++ b/main.cpp
@@ -10,7 +10,7 @@ struct Node {
 
     int value;
 
-    Node(int value) : value(value), prev(nullptr) {}  // 有什么可以改进的？-> 声明为explicit 避免implicit casting，初始化prev指针（POD）
+    explicit Node(int value) : value(value), prev(nullptr) {}  // 有什么可以改进的？-> 声明为explicit 避免implicit casting，初始化prev指针（POD）
 
     void insert(int value) {
         auto node = std::make_unique<Node>(value);
@@ -95,7 +95,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？-> 传递引用常量，避免拷贝
+void print(const List& lst) {  // 有什么值得改进的？-> 传递引用常量，避免拷贝
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);

--- a/main.cpp
+++ b/main.cpp
@@ -62,7 +62,6 @@ struct List {
     typedef ListIterator<T> iterator;
 
     std::unique_ptr<NodeType> head;
-    size_t size;
 
     List() = default;
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,16 +1,17 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include <memory>
+#include <stdexcept>
 
 struct Node {
-    // 这两个指针会造成什么问题？请修复 -> 两个shared_ptr前后节点循环引用
+    // 这两个指针会造成什么问题？请修复
     std::unique_ptr<Node> next;
     Node* prev;
-    // 如果能改成 unique_ptr 就更好了! -> 每个Node的生命周期由上一个节点管理
+    // 如果能改成 unique_ptr 就更好了!
 
     int value;
 
-    explicit Node(int value) : value(value), prev(nullptr) {}  // 有什么可以改进的？-> 声明为explicit 避免implicit casting，初始化prev指针（POD）
+    explicit Node(int value) : value(value), prev(nullptr) {}  // 有什么可以改进的？
 
     void insert(int value) {
         auto node = std::make_unique<Node>(value);
@@ -60,18 +61,16 @@ struct List {
     }
 
     List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？ 
-    // -> l1=l2 => l1=List(l2), 先调用拷贝构造函数，然后调用移动复制函数
 
     List(List &&) = default;
     List &operator=(List &&) = default;
 
     Node *front() const {
-        // TODO: 边界检查
+        
         return head.get();
     }
 
     int pop_front() {
-        // TODO: 边界检查
         int ret = head->value;
         head = std::move(head->next);
         return ret;
@@ -88,14 +87,13 @@ struct List {
     Node *at(size_t index) const {
         auto curr = front();
         for (size_t i = 0; i < index; i++) {
-            // TODO: 边界检查
             curr = curr->next.get();
         }
         return curr;
     }
 };
 
-void print(const List& lst) {  // 有什么值得改进的？-> 传递引用常量，避免拷贝
+void print(const List& lst) {  // 有什么值得改进的？
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);

--- a/main.cpp
+++ b/main.cpp
@@ -3,29 +3,30 @@
 #include <memory>
 
 struct Node {
-    // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
-    // 如果能改成 unique_ptr 就更好了!
+    // 这两个指针会造成什么问题？请修复 -> 两个shared_ptr前后节点循环引用
+    std::unique_ptr<Node> next;
+    Node* prev;
+    // 如果能改成 unique_ptr 就更好了! -> 每个Node的生命周期由上一个节点管理
 
     int value;
 
-    Node(int value) : value(value) {}  // 有什么可以改进的？
+    Node(int value) : value(value) {}  // 有什么可以改进的？-> 声明为explicit 避免implicit casting
 
     void insert(int value) {
-        auto node = std::make_shared<Node>(value);
+        auto node = std::make_unique<Node>(value);
         node->value = value;
-        node->next = next;
+        node->next = std::move(next);
         node->prev = prev;
-        if (prev)
-            prev->next = node;
         if (next)
-            next->prev = node;
+            next->prev = node.get();
+        if (prev)
+            prev->next = std::move(node);
+        // 当前节点 释放？
     }
 
     void erase() {
         if (prev)
-            prev->next = next;
+            prev->next = std::move(next);
         if (next)
             next->prev = prev;
     }
@@ -36,49 +37,53 @@ struct Node {
 };
 
 struct List {
-    std::shared_ptr<Node> head;
+    std::unique_ptr<Node> head;
 
     List() = default;
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        // head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
     }
 
-    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？ 
+    // -> l1=l2 => l1=List(l2), 先调用拷贝构造函数，然后调用移动复制函数
 
     List(List &&) = default;
     List &operator=(List &&) = default;
 
     Node *front() const {
+        // TODO: 边界检查
         return head.get();
     }
 
     int pop_front() {
+        // TODO:边界检查
         int ret = head->value;
-        head = head->next;
+        head = std::move(head->next);
         return ret;
     }
 
     void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
+        auto node = std::make_unique<Node>(value);
         if (head)
-            head->prev = node;
-        head = node;
+            head->prev = node.get();
+        node->next = std::move(head);
+        head = std::move(node);
     }
 
     Node *at(size_t index) const {
         auto curr = front();
         for (size_t i = 0; i < index; i++) {
+            // TODO: 边界检查
             curr = curr->next.get();
         }
         return curr;
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(List lst) {  // 有什么值得改进的？-> 传递引用常量，避免拷贝
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);

--- a/main.cpp
+++ b/main.cpp
@@ -42,18 +42,20 @@ template <typename T> struct List;
 
 template <typename T>
 struct ListIterator {
-    const List<T>* plist;
-    size_t index;
+    Node<T>* node;
 
-    ListIterator(const List<T> *plist, size_t index = 0): plist(plist), index(index) {}
+    ListIterator(Node<T>* node): node(node) {}
 
-    ListIterator& operator+=(int addon) { index+=addon; return *this;}
-
-    Node<T> *operator->() { return plist->at(index); }
-
-    bool operator!=(const ListIterator& rhs) { 
-        return plist != rhs.plist || index != rhs.index;
+    ListIterator& operator+=(int addon) {
+        for (int i=0;i<addon&&node!=nullptr;i++) {
+            node = node->next.get();
+        }
+        return *this;
     }
+
+    Node<T> *operator->() { return node; }
+
+    bool operator!=(const ListIterator<T>& rhs) { return node != rhs.node; }
 };
 
 template <typename T>
@@ -114,17 +116,11 @@ struct List {
     }
 
     iterator begin() const {
-        return iterator(this);
+        return iterator(head.get());
     }
 
     iterator end() const {
-        size_t n = 0;
-        auto curr=front();
-        while (curr) {
-            n ++;
-            curr = curr->next.get();
-        }
-        return iterator(this, n);
+        return iterator(nullptr);
     }
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -18,8 +18,6 @@ struct Node {
         node->value = value;
         node->next = std::move(next);
         node->prev = prev;
-        if (next)
-            next->prev = node.get();
         if (prev)
             prev->next = std::move(node);
     }


### PR DESCRIPTION
1. Node的两个shared_ptr指针造成什么问题？
相邻的两个Node形成循环引用，导致内存泄漏（~Node()被调用的次数不够偏少）
方案1. 采用shared_ptr/weak_ptr
方案2. next指针采用unique_ptr，prev指针采用原始指针。每个Node的生命周期由前一个Node管理；第一个Node的生命周期由List管理

2. 改进Node的构造函数：声明为explicit避免隐式类型转换；初始化prev（原始指针是POD）

3. List拷贝构造函数改成深拷贝：使用尾插法，先遍历到链表尾部，然后从尾部逐一往新链表中插入

4. 为什么删除拷贝赋值函数也不出错？
因为定义了拷贝构造函数和移动赋值函数。赋值语句`l1 = l2`被编译器解释为`l1 = List(l2)`，首先调用拷贝构造函数构造一个临时变量，然后调用移动赋值函数将临时变量移动给l1。

5. print的改进：使用常引用传参，避免不必要的拷贝。

6. template的实现

7. iterator的实现：ListIterator内部记录一个List指针和表示遍历位置的下标。
（假设Iterator的生命周期很短，List不会在遍历过程被释放）
