### PR TITLE
Misaka's first pr.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,32 +4,36 @@
 
 struct Node {
     // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    std::unique_ptr<Node> next;
+    Node* prev;
     // 如果能改成 unique_ptr 就更好了!
 
     int value;
 
     // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
-    }
+    Node(int val)
+        : value(val)
+    {}
 
+    /*
+    * 此函数在当前Node处构造一个Node，并更改指针，但我认为原Node未被删除，
+    * 不是很确定此函数目的，第一次提交暂时按我猜测的方式改写
+    **/
     void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
+        auto node = std::make_unique<Node>(val);
+        if (next)
+            next->prev = node.get();
+        node->next = std::move(next);
         node->prev = prev;
         if (prev)
-            prev->next = node;
-        if (next)
-            next->prev = node;
+            prev->next = std::move(node);
     }
 
     void erase() {
-        if (prev)
-            prev->next = next;
         if (next)
             next->prev = prev;
+        if (prev)
+            prev->next = std::move(next);
     }
 
     ~Node() {
@@ -38,14 +42,33 @@ struct Node {
 };
 
 struct List {
-    std::shared_ptr<Node> head;
+    std::unique_ptr<Node> head;
 
     List() = default;
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        
         // 请实现拷贝构造函数为 **深拷贝**
+        if(!other.head)
+        {
+            head = nullptr;
+        }
+        else
+        {
+            head = std::make_unique<Node>(other.head->value);
+            Node* ptrNew = head.get();
+            Node* ptrPre = other.head.get();
+
+            while(ptrPre->next)
+            {
+                ptrNew->next = std::make_unique<Node>(ptrPre->next->value);
+                ptrNew->next->prev = ptrNew;
+
+                ptrNew = ptrNew->next.get();
+                ptrPre = ptrPre->next.get();
+            }
+        }
     }
 
     List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
@@ -59,16 +82,16 @@ struct List {
 
     int pop_front() {
         int ret = head->value;
-        head = head->next;
+        head = std::move(head->next);
         return ret;
     }
 
     void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
+        auto node = std::make_unique<Node>(value);
         if (head)
-            head->prev = node;
-        head = node;
+            head->prev = node.get();
+        node->next = std::move(head);
+        head = std::move(node);
     }
 
     Node *at(size_t index) const {
@@ -80,7 +103,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(const List& lst) {  // 有什么值得改进的？
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);
@@ -112,7 +135,9 @@ int main() {
     print(a);   // [ 1 4 2 5 7 ]
     print(b);   // [ 1 4 2 8 5 7 ]
 
+    printf("b is cleared.\n");
     b = {};
+    printf("a is cleared.\n");
     a = {};
 
     return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -1,25 +1,28 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include <memory>
+#include <iostream>
 
+template <typename T>
 struct Node {
     // 这两个指针会造成什么问题？请修复
     std::unique_ptr<Node> next;
     Node* prev;
     // 如果能改成 unique_ptr 就更好了!
 
-    int value;
+    T value;
 
     // 这个构造函数有什么可以改进的？
-    Node(int val)
+    Node(const T& val)
         : value(val)
+        , prev(nullptr)
     {}
 
     /*
     * 此函数在当前Node处构造一个Node，并更改指针，但我认为原Node未被删除，
     * 不是很确定此函数目的，第一次提交暂时按我猜测的方式改写
     **/
-    void insert(int val) {
+    void insert(const T& val) {
         auto node = std::make_unique<Node>(val);
         if (next)
             next->prev = node.get();
@@ -41,8 +44,9 @@ struct Node {
     }
 };
 
+template <typename T>
 struct List {
-    std::unique_ptr<Node> head;
+    std::unique_ptr<Node<T>> head;
 
     List() = default;
 
@@ -56,13 +60,13 @@ struct List {
         }
         else
         {
-            head = std::make_unique<Node>(other.head->value);
-            Node* ptrNew = head.get();
-            Node* ptrPre = other.head.get();
+            head = std::make_unique<Node<T>>(other.head->value);
+            Node<T>* ptrNew = head.get();
+            Node<T>* ptrPre = other.head.get();
 
             while(ptrPre->next)
             {
-                ptrNew->next = std::make_unique<Node>(ptrPre->next->value);
+                ptrNew->next = std::make_unique<Node<T>>(ptrPre->next->value);
                 ptrNew->next->prev = ptrNew;
 
                 ptrNew = ptrNew->next.get();
@@ -76,7 +80,7 @@ struct List {
     List(List &&) = default;
     List &operator=(List &&) = default;
 
-    Node *front() const {
+    Node<T> *front() const {
         return head.get();
     }
 
@@ -87,14 +91,14 @@ struct List {
     }
 
     void push_front(int value) {
-        auto node = std::make_unique<Node>(value);
+        auto node = std::make_unique<Node<T>>(value);
         if (head)
             head->prev = node.get();
         node->next = std::move(head);
         head = std::move(node);
     }
 
-    Node *at(size_t index) const {
+    Node<T> *at(size_t index) const {
         auto curr = front();
         for (size_t i = 0; i < index; i++) {
             curr = curr->next.get();
@@ -103,16 +107,17 @@ struct List {
     }
 };
 
-void print(const List& lst) {  // 有什么值得改进的？
+template<typename T>
+void print(const List<T>& lst) {  // 有什么值得改进的？
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
-        printf(" %d", curr->value);
+        std::cout << " " << curr->value;
     }
     printf(" ]\n");
 }
 
 int main() {
-    List a;
+    List<int> a;
 
     a.push_front(7);
     a.push_front(5);


### PR DESCRIPTION
1. 在print函数使用常量引用const&来避免拷贝。
2. Node的next改为unique_ptr，prev使用裸指针。
    在next中使用std::move移动unique_ptr，同时为了保证部分操作合法，改变了next和prev改变值的顺序。
3. 拷贝构造函数进行深拷贝时考虑other是否为空，否则使用链表的顺序遍历依次拷贝各节点，这里采用利用对应节点的value进行构造。
4. 在程序中没有真正使用拷贝赋值函数，唯一进行了List对象的=操作的List b = a;实际上调用的是拷贝构造函数。
5. Node的构造函数将value改为放在初始化列表初始化。