### PR TITLE
Submit hw02 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ file(GLOB HEADER
 add_executable(main ${SRC} ${HEADER})
 
 add_custom_command(TARGET main POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:main> ${CMAKE_SOURCE_DIR}/build/bin/main.exe
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:main> ${CMAKE_SOURCE_DIR}/build/bin/$<TARGET_FILE_NAME:main>
 )
 
 source_group("Source Files"            FILES ${SRC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,16 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-add_executable(main main.cpp)
+file(GLOB SRC
+    "*.cpp"
+)
+
+file(GLOB HEADER
+    "*.h"
+    "*.hpp"
+)
+
+add_executable(main ${SRC} ${HEADER})
+
+source_group("Source Files"            FILES ${SRC})
+source_group("Header Files"            FILES ${HEADER})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,5 +17,9 @@ file(GLOB HEADER
 
 add_executable(main ${SRC} ${HEADER})
 
+add_custom_command(TARGET main POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:main> ${CMAKE_SOURCE_DIR}/build/bin/main.exe
+)
+
 source_group("Source Files"            FILES ${SRC})
 source_group("Header Files"            FILES ${HEADER})

--- a/List.hpp
+++ b/List.hpp
@@ -71,7 +71,7 @@ struct Node {
 		insertAsNextInverted(std::forward<FirstTArg>(firstArg));
 	}
 
-	//c++的函数模板不支持偏特化，只支持重载，这些相似的代码有没有简化的写法？workround: 偏特化functor类模板? tag dispatch?
+	//c++的函数模板不支持偏特化，只支持重载，这些相似的代码有没有简化的写法？workaround: 偏特化functor类模板? tag dispatch?
 
 	void erase() {
 		next->prev = prev;

--- a/List.hpp
+++ b/List.hpp
@@ -1,0 +1,96 @@
+#pragma once
+#include <memory>
+#include <utility>
+
+template <typename T>
+struct Node {
+	// 这两个指针会造成什么问题？请修复
+	std::unique_ptr<Node> next = nullptr;
+	Node* prev = nullptr;
+	// 如果能改成 unique_ptr 就更好了!
+
+	T value;
+
+	template<typename TArg>
+	Node(TArg&& arg) : value(T(std::forward<TArg>(arg))) {}    // 有什么可以改进的？
+
+	template<typename TArg>
+	void insertAsSucc(TArg&& firstArg) {
+		auto node = std::make_unique<Node<T>>(T(std::forward<TArg>(firstArg)));
+		if (next) {
+			next->prev = node.get();
+			node->next = std::move(next);
+		}
+		node->prev = this;
+		this->next = std::move(node);
+	}
+
+	template<typename FirstTArg, typename ...RestTArgs>
+	void insertAsSucc(FirstTArg&& firstArg, RestTArgs&& ...arg) {
+		insertAsSucc(std::forward<FirstTArg>(firstArg));
+		insertAsSucc(std::forward<RestTArgs>(arg)...);
+	}
+
+	void erase() {
+		if (next)
+			next->prev = prev;
+		if (prev)
+			prev->next = std::move(next);
+	}
+
+	~Node() {
+		printf("~Node()\n");   // 应输出多少次？为什么少了？
+	}
+};
+
+
+template <typename T>
+struct List {
+	using NodePtr = std::unique_ptr<Node<T>>;
+	NodePtr head = nullptr;
+
+	List() = default;
+
+	List(List const& other) {
+		printf("List 被拷贝！\n");
+		// 这是浅拷贝！
+		// 请实现拷贝构造函数为 **深拷贝**
+
+		head = std::make_unique<Node<T>>(other.head->value);
+		for (auto curr = front(), currOther = other.head->next.get(); currOther; curr = curr->next.get(), currOther = currOther->next.get()) {
+			curr->insertAsSucc(currOther->value);
+		}
+	}
+
+	List& operator=(List const&) = delete;  // 为什么删除拷贝赋值函数也不出错？
+
+	List(List&&) = default;
+	List& operator=(List&&) = default;
+
+	Node<T>* front() const {
+		return head.get();
+	}
+
+	int pop_front() {
+		int ret = head->value;
+		head = std::move(head->next);
+		return ret;
+	}
+
+	void push_front(int value) {
+		auto node = std::make_unique<Node<T>>(value);
+		if (head) {
+			head->prev = node.get();
+			node->next = std::move(head);
+		}
+		head = std::move(node);
+	}
+
+	Node<T>* at(size_t index) const {
+		auto curr = front();
+		for (size_t i = 0; i < index; i++) {
+			curr = curr->next.get();
+		}
+		return curr;
+	}
+};

--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,4 @@
-@echo off
-IF NOT EXIST "build" mkdir "build"
-cd build
-cmake ..
+cmake -B ./build -DCMAKE_BUILD_TYPE=Release
+cmake --build ./build --target ALL_BUILD --config Release
+.\build\bin\main.exe
+pause

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,4 @@
+@echo off
+IF NOT EXIST "build" mkdir "build"
+cd build
+cmake ..

--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,7 @@ int main() {
 	List<int> a;
 
 	a.push_front(1, 4, 9, 2, 8, 5, 7);
+
 	/*a.push_front(7);
 	a.push_front(5);
 	a.push_front(8);

--- a/main.cpp
+++ b/main.cpp
@@ -1,11 +1,12 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include "List.hpp"
+#include <iterator>
 
 void print(const List<int>& lst) {  // 有什么值得改进的？
 	printf("[");
-	for (auto curr = lst.front(); curr; curr = curr->next.get()) {
-		printf(" %d", curr->value);
+	for (auto&& value : lst) {
+		printf(" %d", value);
 	}
 	printf(" ]\n");
 }
@@ -15,13 +16,14 @@ int main() {
 
 	List<int> a;
 
-	a.push_front(7);
+	a.push_front(1, 4, 9, 2, 8, 5, 7);
+	/*a.push_front(7);
 	a.push_front(5);
 	a.push_front(8);
 	a.push_front(2);
 	a.push_front(9);
 	a.push_front(4);
-	a.push_front(1);
+	a.push_front(1);*/
 
 	print(a);   // [ 1 4 9 2 8 5 7 ]
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,6 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include "List.hpp"
-#include <iterator>
 
 void print(const List<int>& lst) {  // 有什么值得改进的？
 	printf("[");
@@ -12,7 +11,6 @@ void print(const List<int>& lst) {  // 有什么值得改进的？
 }
 
 int main() {
-
 
 	List<int> a;
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,124 +1,43 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
-#include <memory>
+#include "List.hpp"
 
-struct Node {
-    // 这两个指针会造成什么问题？请修复
-    std::unique_ptr<Node> next = nullptr;
-    Node* prev = nullptr;
-    // 如果能改成 unique_ptr 就更好了!
-
-    int value;
-
-    Node(int value) : value(value) {}  // 有什么可以改进的？
-
-    void insert(int value) {
-        auto node = std::make_unique<Node>(value);
-        if (next) {
-            next->prev = node.get();
-            node->next = std::move(next);
-        }
-        node->prev = this;
-        this->next = std::move(node);
-    }
-
-    void erase() {
-        if (next)
-            next->prev = prev;
-        if (prev)
-            prev->next = std::move(next);
-    }
-
-    ~Node() {
-        printf("~Node()\n");   // 应输出多少次？为什么少了？
-    }
-};
-
-struct List {
-    std::unique_ptr<Node> head = nullptr;
-
-    List() = default;
-
-    List(List const &other) {
-        printf("List 被拷贝！\n");
-        // 这是浅拷贝！
-        // 请实现拷贝构造函数为 **深拷贝**
-
-        head = std::make_unique<Node>(other.head->value);
-        for (auto curr = front(), currOther = other.head->next.get(); currOther; curr = curr->next.get(), currOther=currOther->next.get()) {
-            curr->insert(currOther->value);
-        }
-    }
-
-    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
-
-    List(List &&) = default;
-    List &operator=(List &&) = default;
-
-    Node *front() const {
-        return head.get();
-    }
-
-    int pop_front() {
-        int ret = head->value;
-        head = std::move(head->next);
-        return ret;
-    }
-
-    void push_front(int value) {
-        auto node = std::make_unique<Node>(value);        
-        if (head) {
-            head->prev = node.get();
-            node->next = std::move(head);
-        }  
-        head = std::move(node);
-    }
-
-    Node *at(size_t index) const {
-        auto curr = front();
-        for (size_t i = 0; i < index; i++) {
-            curr = curr->next.get();
-        }
-        return curr;
-    }
-};
-
-void print(const List& lst) {  // 有什么值得改进的？
-    printf("[");
-    for (auto curr = lst.front(); curr; curr = curr->next.get()) {
-        printf(" %d", curr->value);
-    }
-    printf(" ]\n");
+void print(const List<int>& lst) {  // 有什么值得改进的？
+	printf("[");
+	for (auto curr = lst.front(); curr; curr = curr->next.get()) {
+		printf(" %d", curr->value);
+	}
+	printf(" ]\n");
 }
 
 int main() {
 
-  
-    List a;
 
-    a.push_front(7);
-    a.push_front(5);
-    a.push_front(8);
-    a.push_front(2);
-    a.push_front(9);
-    a.push_front(4);
-    a.push_front(1);
+	List<int> a;
 
-    print(a);   // [ 1 4 9 2 8 5 7 ]
+	a.push_front(7);
+	a.push_front(5);
+	a.push_front(8);
+	a.push_front(2);
+	a.push_front(9);
+	a.push_front(4);
+	a.push_front(1);
 
-    a.at(2)->erase();
+	print(a);   // [ 1 4 9 2 8 5 7 ]
 
-    print(a);   // [ 1 4 2 8 5 7 ]
+	a.at(2)->erase();
 
-    List b = a;
+	print(a);   // [ 1 4 2 8 5 7 ]
 
-    a.at(3)->erase();
+	List<int> b = a;
 
-    print(a);   // [ 1 4 2 5 7 ]
-    print(b);   // [ 1 4 2 8 5 7 ]
+	a.at(3)->erase();
 
-    b = {};
-    a = {};
+	print(a);   // [ 1 4 2 5 7 ]
+	print(b);   // [ 1 4 2 8 5 7 ]
 
-    return 0;
+	b = {};
+	a = {};
+
+	return 0;
 }

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,5 @@
 set -e
 cmake -B build
 cmake --build build
-build/main
+build/bin/main
+read -p "Press any key to resume ..."


### PR DESCRIPTION
删除拷贝赋值函数也不会出错的原因是：`main()` 函数里没有出现链表对象的拷贝赋值。`List b = a;` 处调用的是`b`的拷贝构造函数，因为此时 `b` 完成的是初始化而不是赋值。`a = {};`调用的是`a`的移动赋值函数`List &operator=(List &&) = default;`，相当于`a.operator=(List{nullptr, nullptr, 0});`，这一点可通过 https://cppinsights.io/ 验证。

作业里创建了`List<T>`类模板，使用`unique_ptr`和裸指针构造双向链表。为了方便管理，使语义更加通顺，设置了头尾哨兵，以此保证数据区内前向和后向的指针始终指向一个有效的节点。当`List<T>`生命周期结束时，头哨兵管理的`Node<T>`得到释放，其余`Node<T>`也将从前往后依次释放。

作业对`Node`构造函数进行了改进，允许在构造时设置前后向指针，通过perfect forwarding, copy elision减少了不必要的overhead。此外，还支持了 range-based for 循环，插入函数的变长参数。

`~Node()` 在正确实现深拷贝的情况下应该调用13次，因为一共有13个node被创建。我的版本因为设置了头尾哨兵，所以`~Node()` 调用了21次。具体来看，`a`和`b`多创建了4个哨兵，`a = {};b = {};` 又多了4个被moved from的哨兵，因此 13+4+4 = 21次。