### PR TITLE
hw02 of fadedzipper

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,35 +1,47 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include <memory>
+#include <iostream>
+#include <assert.h>
+using namespace std;
 
 struct Node {
     // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    unique_ptr<Node> next{nullptr};
+    Node *prev;
     // 如果能改成 unique_ptr 就更好了!
 
     int value;
 
     // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
-    }
+    Node(int val): value(val) {}
 
     void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
-        node->prev = prev;
-        if (prev)
-            prev->next = node;
-        if (next)
-            next->prev = node;
+        auto node = make_unique<Node>(val);
+        // cout << 1 << endl;
+    
+        if (next) {
+        // cout << 1 << endl;
+            next->prev = node.get();
+        // cout << 1 << endl;
+            node->next = move(next);
+        }
+        // cout << 1 << endl;
+        node->prev = this;
+        next = move(node);
     }
 
     void erase() {
-        if (prev)
-            prev->next = next;
-        if (next)
+        if (!prev) {
+            assert(false);
+        }
+        if (next) {
             next->prev = prev;
+            prev->next = move(next);
+        }
+        else {
+            prev->next = nullptr;
+        }
     }
 
     ~Node() {
@@ -38,13 +50,22 @@ struct Node {
 };
 
 struct List {
-    std::shared_ptr<Node> head;
+    std::unique_ptr<Node> head;
 
     List() = default;
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        head = std::make_unique<Node>(other.head->value);
+        
+        auto other_head = other.head->next.get();
+        auto this_head = head.get();
+
+
+        for (; other_head; other_head = other_head->next.get()) {
+            this_head->insert(other_head->value);
+            this_head = this_head->next.get();
+        }
         // 请实现拷贝构造函数为 **深拷贝**
     }
 
@@ -59,16 +80,17 @@ struct List {
 
     int pop_front() {
         int ret = head->value;
-        head = head->next;
+        head = move(head->next);
         return ret;
     }
 
     void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
-        if (head)
-            head->prev = node;
-        head = node;
+        auto node = std::make_unique<Node>(value);
+        if (head) {
+            head->prev = node.get();
+            node->next = move(head);
+        }
+        head = move(node);
     }
 
     Node *at(size_t index) const {
@@ -80,7 +102,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(List const &lst) {  // 有什么值得改进的？
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);
@@ -88,6 +110,13 @@ void print(List lst) {  // 有什么值得改进的？
     printf(" ]\n");
 }
 
+void test_node_insert() {
+    auto ptr = make_unique<Node>(19);
+    ptr->insert(1);
+    
+    cout << ptr->value << endl;
+    cout << ptr->next->value << endl;
+}
 int main() {
     List a;
 
@@ -102,10 +131,12 @@ int main() {
     print(a);   // [ 1 4 9 2 8 5 7 ]
 
     a.at(2)->erase();
+    // cout << "erase()" << endl;
 
     print(a);   // [ 1 4 2 8 5 7 ]
 
     List b = a;
+    // b = a;
 
     a.at(3)->erase();
 
@@ -114,6 +145,10 @@ int main() {
 
     b = {};
     a = {};
+    // cout << "b a destruct" << endl;
 
     return 0;
+
+    // test_node_insert();
 }
+


### PR DESCRIPTION
#### 说明为什么可以删除拷贝赋值函数
* 在测试main()函数中没有用到拷贝赋值函数，只使用了拷贝构造，如果有用到这个函数，就会报错的。

### 解释代码
#### 这两个共享指针会造成什么问题？
* 会造成循环引用的问题。
#### 这个构造函数可以怎么改进？
* 可以用初始化列表，可以减少一次初始化赋值。
#### 解构函数应该输出多少次？为什么少了？
* 应该说的shared_ptr指针的问题。shared_ptr循环引用就会造成内存泄露，相关的堆资源相互指向，main函数里面的shared_ptr指针指向的资源在shared_ptr作用域结束（即main执行结束的时候）就不会被释放掉，所以~node()输出就少了。
* 在改用unique_ptr和原始指针之后就正好释放13次。没有问题。

### 遇到了一个问题
1. 一开始的时候是使用shared_ptr 和weak_ptr的组合来解决这个问题，但是遇到了麻烦。在Node::insert函数中，为了让新的node节点的prev域（类型是weak_ptr）指向当前的对象。需要把this指针转成weak_ptr。
``` 
node.prev = std::shared_ptr<Node>(this);
```
2. 每次运行到这里都段错误。感觉这里把this转换成shared_ptr，之后很快智能指针就离开作用域就把this对象给释放掉了。所以产生了错误。
3. 看网上的实现都是用的双weak_ptr指针，所以也不太明白具体为什么。
4. 最后换成了unique就省心多了。而且也符合双链表的意义。