### PR TITLE
hw02 weakptr_Ver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 GNUmakefile
+mind.md


### PR DESCRIPTION
- 在print上使用引用传值避免发生拷贝。
- 为了解决循环引用问题使用`share和weak智能指针`或`裸指针和unique智能指针`搭配。一上来没注意将next设置为weak_ptr，而将prev设置为share_ptr，然后在print的时候发现了错误，原来是在`push_front()`函数中head=node中将node->next=head的next弱指针给释放掉了,导致没有连上。所以必须要将next设置为share_ptr，prev为weak_ptr，而不能相反（如果用这俩的话）。我也尝试了一下next和prev同时设置为weak_ptr，只有head为shared_ptr。但是这在head=xxx的时候释放当前节点导致节点没了，必须先拷贝一份链表再执行这种类型操作，这样就很不合理。
- 这分儿等我再尝试一下: P
- 这个用了for循环+at来遍历other，不如他们的while简洁u1s1。
- 根据三五法则要么定义要么删除，默认生成的是浅拷贝，为了避免二次释放，可以将其删除禁止拷贝赋值。
- 加了explicit避免隐式转换，初始化应该是内联的提高性能。