### PR TITLE
HW02 my solution.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,33 +1,41 @@
 /* 基于智能指针实现双向链表 */
+#include <cstddef>
 #include <cstdio>
 #include <memory>
 
 struct Node {
     // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    // 存在循环引用，会导致无法自动释放，典型场景：双节点成环
+    // std::shared_ptr<Node> next;
+    // std::weak_ptr<Node> prev;
     // 如果能改成 unique_ptr 就更好了!
+    std::unique_ptr<Node> next;
+    Node *prev;
 
     int value;
 
     // 这个构造函数有什么可以改进的？
     Node(int val) {
         value = val;
+        next = nullptr;
+        prev = nullptr;
     }
 
     void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
+        auto node = std::make_unique<Node>(val);
+
+        node->next = std::move(next);
         node->prev = prev;
-        if (prev)
-            prev->next = node;
+
         if (next)
-            next->prev = node;
+            next->prev = node.get();
+        if (prev)
+            prev->next = std::move(node);
     }
 
     void erase() {
         if (prev)
-            prev->next = next;
+            prev->next = std::move(next);
         if (next)
             next->prev = prev;
     }
@@ -38,17 +46,36 @@ struct Node {
 };
 
 struct List {
-    std::shared_ptr<Node> head;
+    std::unique_ptr<Node> head;
 
     List() = default;
 
-    List(List const &other) {
-        printf("List 被拷贝！\n");
+    List(List const &other)  {
+#define DEEP_COPY
+#ifndef DEEP_COPY
+        printf("List 被浅拷贝！\n");
         head = other.head;  // 这是浅拷贝！
-        // 请实现拷贝构造函数为 **深拷贝**
+#else
+        // 请实现拷贝构造函数为 **深拷贝**;
+        printf("List 被深拷贝！\n");
+        if (other.head)
+        {
+            head = std::make_unique<Node>(other.head->value);
+        }
+        Node *p = other.head.get();
+        Node *q = head.get();
+        while (p->next)
+        {
+            q->next = std::make_unique<Node>(p->next->value);
+            q->next->prev = q;
+            q = q->next.get();
+            p = p->next.get();
+        }
+#endif
     }
 
     List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    // 因为当拷贝赋值不行时，会尝试通过构造函数，隐式类型转换，构造赋值, 构造函数加上explicit就会编译出错。
 
     List(List &&) = default;
     List &operator=(List &&) = default;
@@ -59,16 +86,16 @@ struct List {
 
     int pop_front() {
         int ret = head->value;
-        head = head->next;
+        head = std::move(head->next);
         return ret;
     }
 
     void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
+        auto node = std::make_unique<Node>(value);
         if (head)
-            head->prev = node;
-        head = node;
+            head->prev = node.get();
+        node->next = std::move(head);
+        head = std::move(node);
     }
 
     Node *at(size_t index) const {
@@ -80,7 +107,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(const List &lst) {  // 有什么值得改进的？ 应该改用常量引用，避免触发类型转换构造或者是拷贝赋值
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);


### PR DESCRIPTION
1. 改用`unique_ptr`实现。避免`share_ptr`带来的循环引用内存泄漏问题。双向链表中当前节点如果有前趋节点，则生命周期交由前趋节点管理，所以next使用`unique_ptr`类型去持有下一个节点的内存所有权。prev使用原始指针，作为一个弱引用。
2. 修改浅拷贝为深拷贝。
3. 深处拷贝赋值函数后不出错是因为无法拷贝赋值时会自动转为调用构造赋值（和隐式类型转换流程类似），而之前的深拷贝函数满足对应的参数，会被调用用来构造，然后再通过移动构造，move给对应的左值。简而言之：原来a=b是a.copyFrom(b)，现在是rhs.createFrom(b)->rhs.moveTo(a)完成的。如果给构造函数加上explicit，就走不通这条路了。
4. Node构造函数的改进，没有get到点. 是指没有初始化所有成员变量吗？

模板和迭代器还不是很了解，下次再尝试吧。