### PR TITLE
hw02

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,30 +4,31 @@
 
 struct Node {
     // 这两个指针会造成什么问题？请修复
+    // std::unique_ptr<Node> next;
+    // std::unique_ptr<Node> prev;
     std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    std::weak_ptr<Node> prev;
     // 如果能改成 unique_ptr 就更好了!
 
-    int value;
+    int value{};
 
     // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
+    Node(int val) :value(val){
     }
 
     void insert(int val) {
         auto node = std::make_shared<Node>(val);
         node->next = next;
         node->prev = prev;
-        if (prev)
-            prev->next = node;
+        if (!prev.expired())
+            prev.lock()->next = node;
         if (next)
             next->prev = node;
     }
 
     void erase() {
-        if (prev)
-            prev->next = next;
+        if (!prev.expired())
+            prev.lock()->next = next;
         if (next)
             next->prev = prev;
     }
@@ -44,8 +45,18 @@ struct List {
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        // head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
+        auto thead = other.head;
+        head=std::make_shared<Node>(thead->value);
+        auto tmp=head;
+        while(thead->next)
+        {
+            head->next=std::make_shared<Node>(thead->next->value);
+            head=head->next;
+            thead=thead->next;
+        }
+        head=tmp;
     }
 
     List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
@@ -80,7 +91,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(List& lst) {  // 有什么值得改进的？
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);

--- a/main.cpp
+++ b/main.cpp
@@ -53,6 +53,7 @@ struct List {
         while(thead->next)
         {
             head->next=std::make_shared<Node>(thead->next->value);
+            head->next->prev=head;
             head=head->next;
             thead=thead->next;
         }


### PR DESCRIPTION
开始的两个shared_ptr会导致循环引用的情况，引用计数永远不可能清零，所以要用shred_ptr与weak_ptr的组合或者原始指针与unique_ptr的组合来解决这个问题，这里我先用前者解决了，有时间再写unique_ptr。
value我加了一个列表初始化，感觉可能会在某些条件判断时可能用到（实际并没有
构造函数应该改成参数列表，不然会先初始化再赋值多了一道工序。
浅拷贝改成深拷贝没什么说的，虽然写的很丑陋但是测试了一下好像没什么问题。
之所以删除拷贝赋值函数也不出错是因为实际使用的是shared_ptr的浅拷贝
print把传值改成传引用可以少复制一次