### PR TITLE
HW02

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,37 +3,42 @@
 #include <memory>
 
 struct Node {
-    // 这两个指针会造成什么问题？请修复
+    // 这两个指针会造成什么问题？请修复--share_ptr的循环引用
     std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    // std::shared_ptr<Node> prev;
+    std::weak_ptr<Node> prev;
     // 如果能改成 unique_ptr 就更好了!
 
     int value;
 
-    // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
+    // 这个构造函数有什么可以改进的？-- 这是先初始化再赋值，多了一步操作，
+    Node(int val):value(val) {
+        // value = val;
     }
 
     void insert(int val) {
         auto node = std::make_shared<Node>(val);
-        node->next = next;
+        node->next = next; 
         node->prev = prev;
-        if (prev)
-            prev->next = node;
+        // if (prev)
+        //     prev->next = node;
+        if (!prev.expired())//lock()产生share_ptr
+            prev.lock()->next = node;
         if (next)
             next->prev = node;
     }
 
     void erase() {
-        if (prev)
-            prev->next = next;
+        // if (prev)
+        //     prev->next = next;
+        if (!prev.expired())
+            prev.lock()->next = next;
         if (next)
             next->prev = prev;
     }
 
     ~Node() {
-        printf("~Node()\n");   // 应输出多少次？为什么少了？
+        printf("~Node()\n");   // 应输出多少次？为什么少了？-- 13次，循环引用不会析构
     }
 };
 
@@ -44,11 +49,25 @@ struct List {
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        // head = other.head;  // 这是浅拷贝！---复制出来的指针还是指向同一块内存--有double free的问题
         // 请实现拷贝构造函数为 **深拷贝**
+        head = std::make_shared<Node>(other.head->value);//深拷贝利用make_share申请内存，一个一个节点复制过去
+        auto tmp_cur = head;
+        auto tmp = other.head;
+        while(tmp->next)
+        {
+            auto tmp_next = std::make_shared<Node>(tmp->next->value);
+            tmp_cur->next = tmp_next;
+            tmp_next->prev = tmp_cur;
+            tmp = tmp->next;
+            tmp_cur = tmp_next;
+
+        }        
+
+
     }
 
-    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？--因为定义了移动赋值函数，赋值时会自动用无参构造和移动赋值
 
     List(List &&) = default;
     List &operator=(List &&) = default;
@@ -80,7 +99,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(List const& lst) {  // 有什么值得改进的？--传常引用避免拷贝
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);


### PR DESCRIPTION
1、避免函数参数不必要的拷贝：参数传递传值改为传常量引用
2、修复智能指针造成的问题：两个share_ptr相互指向，形成环，造成内存泄漏
3、改用 `unique_ptr<Node>`：### **暂时没做**
4、实现拷贝构造函数为深拷贝：浅拷贝直接复制指针，都指向同一块内存，深拷贝先申请内存，一个一个节点拷贝，具体实现有参考其他同学的实现
5、说明为什么可以删除拷贝赋值函数：因为定义了移动赋值函数，赋值时会自动用无参构造和移动赋值
6、改进 `Node` 的构造函数：利用初始化列表初始化