### PR TITLE
HW02

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include <memory>
+#include <vector>
 
 struct Node {
     // 这两个指针会造成什么问题？请修复
@@ -11,9 +12,8 @@ struct Node {
     int value;
 
     // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
-    }
+    // 直接利用初始化列表，避免初始化两次
+    Node(int val): value(val) {}
 
     void insert(int val) {
         auto node = std::make_shared<Node>(val);
@@ -44,8 +44,15 @@ struct List {
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        // head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
+        std::vector<int> lst;
+        for (auto curr = other.front(); curr; curr = curr->next.get()) {
+            lst.emplace_back(curr->value);
+        }
+        for (auto curr = lst.rbegin(); curr != lst.rend(); ++curr) {
+            this->push_front(*curr);
+        }
     }
 
     List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
@@ -80,7 +87,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(List const& lst) {  // 有什么值得改进的？ -> 常引用，减少拷贝
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);

--- a/main.cpp
+++ b/main.cpp
@@ -1,35 +1,35 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include <memory>
-#include <vector>
 
 struct Node {
     // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    std::unique_ptr<Node> next;
+    Node* prev = nullptr;
     // 如果能改成 unique_ptr 就更好了!
 
     int value;
 
     // 这个构造函数有什么可以改进的？
     // 直接利用初始化列表，避免初始化两次
-    Node(int val): value(val) {}
+    explicit Node(int val): value(val) {}
 
     void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
+        auto node = std::make_unique<Node>(val);
+        node->next = std::move(next);
         node->prev = prev;
-        if (prev)
-            prev->next = node;
+
         if (next)
-            next->prev = node;
+            next->prev = node.get();
+        if (prev)
+            prev->next = std::move(node);
     }
 
     void erase() {
-        if (prev)
-            prev->next = next;
         if (next)
             next->prev = prev;
+        if (prev)
+            prev->next = std::move(next);
     }
 
     ~Node() {
@@ -38,7 +38,7 @@ struct Node {
 };
 
 struct List {
-    std::shared_ptr<Node> head;
+    std::unique_ptr<Node> head;
 
     List() = default;
 
@@ -46,12 +46,16 @@ struct List {
         printf("List 被拷贝！\n");
         // head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
-        std::vector<int> lst;
-        for (auto curr = other.front(); curr; curr = curr->next.get()) {
-            lst.emplace_back(curr->value);
+        head.reset();
+
+        auto cur = other.head.get();
+        while (cur->next) {
+            cur = cur->next.get();
         }
-        for (auto curr = lst.rbegin(); curr != lst.rend(); ++curr) {
-            this->push_front(*curr);
+
+        while (cur) {
+            this->push_front(cur->value);
+            cur = cur->prev;
         }
     }
 
@@ -65,17 +69,18 @@ struct List {
     }
 
     int pop_front() {
-        int ret = head->value;
-        head = head->next;
+        int ret = head.get()->value;
+        head = std::move(head.get()->next);
         return ret;
     }
 
     void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
-        if (head)
-            head->prev = node;
-        head = node;
+        auto node = std::make_unique<Node>(value);
+        if (head) {
+            head->prev = node.get();
+        }
+        node->next = std::move(head);
+        head = std::move(node);
     }
 
     Node *at(size_t index) const {


### PR DESCRIPTION
- [x] 避免函数参数不必要的拷贝 5 分
- [x] 修复智能指针造成的问题 10 分
   - shared_ptr 计数始终不为 0，造成内存泄漏，利用 unique_ptr 和 原始指针来改写
- [x] 改用 `unique_ptr<Node>` 10 分
- [x] 实现拷贝构造函数为深拷贝 15 分
- [x] 说明为什么可以删除拷贝赋值函数 5 分
  - List b = a 调用的是拷贝构造函数，如果是 List b; b = a; 那么会调用拷贝赋值函数而报错
- [x] 改进 `Node` 的构造函数 5 分