### PR TITLE
补充析构是否也能解决问题？

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,54 +1,79 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include <memory>
+#include <iostream>
 
 struct Node {
     // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    /* edit by Liu: 问题 容易引起内存泄漏 如直接将head=nullptr	*/
+    /* edit by Liu: 后面有指着他的节点 故链表不会被删除		*/
+    /* edit by Liu: 要彻底删除链表要写循环 很麻烦	 	*/
+    /* edit by Liu: 未修改前少输出的"~Node()"就是这个原因 	*/
+    std::unique_ptr<Node> next;
+    Node * prev;
     // 如果能改成 unique_ptr 就更好了!
+    /* edit by Liu: 因为头节点 head和其后节点的prev都要指向它	*/
+    /* edit by Liu: 所以head用unique prev一定不能用unique	*/
+    /* edit by Liu: 所以next用了unique 而prev用了老指针		*/
 
     int value;
 
     // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
-    }
-
+    /* edit by Liu: 改变了初始化的方式 禁止使用隐式类型转换 	*/
+    explicit Node(int val) : value(val), prev(NULL), next(nullptr) {};
+    
+    /* edit by Liu: 这里的insert是什么意思没看懂 		*/
+    /* edit by Liu: 为什么是把自己替换了 不是插一个节点吗 	*/
     void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
-        node->prev = prev;
-        if (prev)
-            prev->next = node;
+        auto node = std::make_unique<Node>(val);
+	node->next = std::move(next);
+	node->prev = prev;
         if (next)
-            next->prev = node;
+            next->prev = node.get();
+        if (prev)
+            prev->next = std::move(next);
     }
 
     void erase() {
-        if (prev)
-            prev->next = next;
         if (next)
             next->prev = prev;
+        if (prev)
+            prev->next = std::move(next);
     }
 
     ~Node() {
         printf("~Node()\n");   // 应输出多少次？为什么少了？
+    /* edit by Liu: 应该是13次 此代码输出为13次 	*/
+    /* edit by Liu: 但是未修改前因为share_ptr造成的问题	*/
+    /* edit by Liu: 导致内存泄露没有释放链表占的内存	*/
     }
 };
 
 struct List {
-    std::shared_ptr<Node> head;
+    std::unique_ptr<Node> head;
 
     List() = default;
+    //List() = delete;
+    //explicit List() = default;
+    List(int val) : head(std::make_unique<Node>(val)) {};
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
+    /* edit by Liu: 因为unique不能赋值 还是用的老指针处理数据 	*/
+	head = std::make_unique<Node>(other.head->value);
+	for (auto ptr_m=front(),ptr_o=other.front()->next.get(); ptr_o; ptr_m=ptr_m->next.get(),ptr_o=ptr_o->next.get()) {
+	    ptr_m->next = std::make_unique<Node>(ptr_o->value);
+	    ptr_m->next->prev = ptr_m;
+	    ptr_m->next->value = ptr_o->value;
+	}
     }
 
     List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    /* edit by Liu: 因为编译器认为a={}调用了移动赋值函数 	*/
+    /* edit by Liu: 将{}处理为空的默认构造函数List()	 	*/
+    /* edit by Liu: 如果将空的默认构造函数删除 编译就不过 	*/
+    /* edit by Liu: 事实默认构造函数不允许隐式类型转换也编译不过*/
 
     List(List &&) = default;
     List &operator=(List &&) = default;
@@ -59,16 +84,16 @@ struct List {
 
     int pop_front() {
         int ret = head->value;
-        head = head->next;
+        head = std::move(head->next);
         return ret;
     }
 
     void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
+        auto node = std::make_unique<Node>(value);
         if (head)
-            head->prev = node;
-        head = node;
+            head->prev = node.get();
+        node->next = std::move(head);
+        head = std::move(node);
     }
 
     Node *at(size_t index) const {
@@ -79,8 +104,8 @@ struct List {
         return curr;
     }
 };
-
-void print(List lst) {  // 有什么值得改进的？
+/* edit by Liu: 传引用不会调用复制构造函数，print函数不会改变值，所以用常引用 */
+void print(const List & lst) {  // 有什么值得改进的？
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);
@@ -90,6 +115,7 @@ void print(List lst) {  // 有什么值得改进的？
 
 int main() {
     List a;
+    //List a(11);
 
     a.push_front(7);
     a.push_front(5);


### PR DESCRIPTION
### shared_prt造成的内存泄漏
个人认为因为默认析构函数只将shared_ptr类型的head析构掉，并不能释放有内部节点相互指向的整个链表的内存，想解决将shared_ptr改为unique_ptr是一种方法，使用析构函数一个个的完整释放每个节点是否也是一种方法？

- 使用传引用可避免不必要的拷贝
- head和next使用unique_ptr类型指针一个释放后引起一连串的释放，解决
- 编译器认为a={}调用了移动赋值函数，将{}处理为空的默认构造函数List()；如果将空的默认构造函数删除，编译就不过；事实默认构造函数不允许隐式类型转换，即不让编译器把{}认为是空默认构造函数，也编译不过。