### PR TITLE
hw2

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -70,7 +70,16 @@ struct List {
         }
     }
 
-    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    // List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    // 删除不出错是因为，临时变量是右值，a = {}, b = {} 调用是移动赋值。
+    // 如果非要写赋值，可以改换成这个。
+    List &operator=(const List &other)
+    {
+        head = {};
+        this->~List();
+        new(this) List{other};
+        return *this;
+    }
 
     // 转移头的控制权
     List(List &&) = default;
@@ -128,7 +137,10 @@ int main() {
 
     print(a);   // [ 1 4 2 8 5 7 ]
 
-    List b = a;
+
+//  List b = a;
+    List b;
+    b = a;
 
     a.at(3)->erase();
 

--- a/main.cpp
+++ b/main.cpp
@@ -3,53 +3,76 @@
 #include <memory>
 
 struct Node {
-    // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    // 这两个指针会造成什么问题？请修复 //死锁
+    /*考虑到让头指针为空时，释放整个链表*/
+    std::unique_ptr<Node>    next;
+    Node                    *prev;
     // 如果能改成 unique_ptr 就更好了!
 
     int value;
 
-    // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
-    }
+    // 这个构造函数有什么可以改进的？ 
+    // 初始化列表提高性能, explicit防止莫名的隐式类型转换
+    explicit Node(int val) : value{val} { }
 
     void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
+        auto node = std::make_unique<Node>(val);
+        node->next = std::move(next);
         node->prev = prev;
-        if (prev)
-            prev->next = node;
         if (next)
-            next->prev = node;
-    }
-
-    void erase() {
+            next->prev = node.get();
         if (prev)
-            prev->next = next;
+            prev->next = std::move(node);
+    }
+    void erase() {    
         if (next)
             next->prev = prev;
+        if (prev)
+            prev->next = std::move(next);
     }
 
     ~Node() {
-        printf("~Node()\n");   // 应输出多少次？为什么少了？
+        static int counter = 1;
+        printf("%d ~Node()\n", counter++);   // 应输出多少次？为什么少了？//应该13次，但锁死了
     }
 };
 
 struct List {
-    std::shared_ptr<Node> head;
+    std::unique_ptr<Node> head;
 
     List() = default;
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        //head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
+
+        // 处理头指针
+        if(other.head == nullptr)
+            return;
+        head = std::make_unique<Node>(other.head->value);
+
+        // 初始化当前指针
+        Node                 *cur_ptr = head.get();                 //this
+        std::unique_ptr<Node> cur_ptr_nxt;                          //this
+
+        Node                 *cur_ptr_oth = other.head->next.get(); //other
+
+        // 遍历链表
+        while(cur_ptr_oth != nullptr)
+        {
+            cur_ptr_nxt = std::make_unique<Node>(cur_ptr_oth->value);
+            cur_ptr_nxt->prev = cur_ptr;
+            cur_ptr->next = std::move(cur_ptr_nxt);
+
+            cur_ptr = cur_ptr->next.get();
+            cur_ptr_oth = cur_ptr_oth->next.get();
+        }
     }
 
     List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
 
+    // 转移头的控制权
     List(List &&) = default;
     List &operator=(List &&) = default;
 
@@ -59,16 +82,16 @@ struct List {
 
     int pop_front() {
         int ret = head->value;
-        head = head->next;
+        head = std::move(head->next);
         return ret;
     }
 
     void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
-        if (head)
-            head->prev = node;
-        head = node;
+        auto node = std::make_unique<Node>(value);
+        node->next = std::move(head);
+        if (node->next)
+            node->next->prev = node.get();
+        head = std::move(node);
     }
 
     Node *at(size_t index) const {
@@ -80,7 +103,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(const List &lst) {  // 有什么值得改进的？不要深拷贝,const &就行
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+rm -rf build 
 cmake -B build
 cmake --build build
 build/main


### PR DESCRIPTION
1.对于（可能）比较大的数据结构，用const &传递常引用，避免遍历拷贝。
2.我们的目的在于将头指针置空时释放整个链表，但`head->next->prev`仍然占据一个引用计数，会锁死原先`head`指向的内存，不能如愿释放。因此应该将`prev`改成`weak_ptr`类型避开对前置节点的引用计数。或者如最后版本的代码，把`next`换成`unique_ptr`类型, `prev`换成`Node*`类型。这里，由于`head`作为数据结构起点的特殊性，我们应该让`next`指针占据主导地位。
3.如2。
4.通过两个指针`cur_ptr`,`cur_ptr_nex`指向一前一后两个节点，不断跟进，实现深拷贝。
5.之所以可以删除拷贝构造函数，是因为`a={ }`中，等号右边会用空的初始化列表生成一个临时的List变量，再赋值给`a`。临时变量是右值，会调用移动赋值函数，因此拷贝赋值可以删除。如果非要写拷贝赋值，可以见提交的代码。
6.改进构造函数有两个方面，一是直接对成员进行初始化，而不是在函数体中赋值。二是尽量将构造函数，特别是单参数构造函数声明为explicit，避免莫名其妙的隐式类型转换。