### PR TITLE
hw02

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,13 +4,15 @@
 
 struct Node {
     // 这两个指针会造成什么问题？请修复
+    // 造成循环引用，把其中一个改为weak_ptr可以解决
     std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
-    // 如果能改成 unique_ptr 就更好了!
+    std::weak_ptr<Node> prev;
+    // 如果能改成 unique_ptr 就更好了!  不会，看了其他同学的答案
 
     int value;
 
     // 这个构造函数有什么可以改进的？
+    // 不知道
     Node(int val) {
         value = val;
     }
@@ -19,15 +21,15 @@ struct Node {
         auto node = std::make_shared<Node>(val);
         node->next = next;
         node->prev = prev;
-        if (prev)
-            prev->next = node;
+        if (prev.expired())
+            prev.lock()->next = node;
         if (next)
             next->prev = node;
     }
 
     void erase() {
-        if (prev)
-            prev->next = next;
+        if (prev.expired())
+            prev.lock()->next = next;
         if (next)
             next->prev = prev;
     }

--- a/main.cpp
+++ b/main.cpp
@@ -7,7 +7,7 @@ struct Node {
     // 造成循环引用，把其中一个改为weak_ptr可以解决
     std::shared_ptr<Node> next;
     std::weak_ptr<Node> prev;
-    // 如果能改成 unique_ptr 就更好了!  不会，看了其他同学的答案
+    // 如果能改成 unique_ptr 就更好了!
 
     int value;
 
@@ -19,7 +19,7 @@ struct Node {
         auto node = std::make_shared<Node>(val);
         node->next = next;
         node->prev = prev;
-        if (prev.expired())
+        if (!prev.expired())
             prev.lock()->next = node;
         if (next)
             next->prev = node;
@@ -59,7 +59,7 @@ struct List {
         }
     }
 
-    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？ 看了其他人的答案，如果把拷贝赋值删了，就会自动使用移动赋值
+    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？ 如果把拷贝赋值删了，就会自动使用移动赋值
 
     List(List &&) = default;
     List &operator=(List &&) = default;

--- a/main.cpp
+++ b/main.cpp
@@ -12,9 +12,7 @@ struct Node {
     int value;
 
     // 这个构造函数有什么可以改进的？
-    // 不知道
-    Node(int val) {
-        value = val;
+    Node(int val) : value(val) {
     }
 
     void insert(int val) {
@@ -28,7 +26,7 @@ struct Node {
     }
 
     void erase() {
-        if (prev.expired())
+        if (!prev.expired())
             prev.lock()->next = next;
         if (next)
             next->prev = prev;
@@ -46,11 +44,22 @@ struct List {
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        //head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
+        auto o = other.head;
+        auto p = std::make_shared<Node>(o->value);
+        auto prev = p;
+        head = p;
+        while (o->next) {
+            o = o->next;
+            p->next = std::make_shared<Node>(o->value);
+            p->prev = prev;
+            prev = p;
+            p = p->next;
+        }
     }
 
-    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？ 看了其他人的答案，如果把拷贝赋值删了，就会自动使用移动赋值
 
     List(List &&) = default;
     List &operator=(List &&) = default;
@@ -82,7 +91,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(List const& lst) {  // 有什么值得改进的？ 改成引用传值
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);


### PR DESCRIPTION
1. 函数参数改为引用传值，避免拷贝
2. 两个shared_ptr 会造成循环引用，把一个改为weak_ptr
3. 不会
4. 在代码中
5. 因为有默认的移动赋值函数
6. 使用初始化列表