### PR TITLE
Hw02 && 模板 && 迭代器

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,77 +1,98 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include <memory>
+#include <utility>
+#include <type_traits>
 
+template <typename T>
 struct Node {
     // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    // 对于双向链表，相邻项之间存在循环引用，引用计数无法归零释放空间。
+    // 对于双向链表，可以看作前一项“拥有”后一项。
+    // 而后一项保留前一项的Node*指针
+    std::unique_ptr<Node> next;
+    Node* prev;
     // 如果能改成 unique_ptr 就更好了!
 
-    int value;
+    T value;
 
-    // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
-    }
+    // 这个构造函数有什么可以改进的？:value直接根据val构造而不是默认构造后赋值。
+    Node(T val): value(val), prev(nullptr) {}
 
-    void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
-        node->prev = prev;
-        if (prev)
-            prev->next = node;
-        if (next)
-            next->prev = node;
-    }
+    // insert会导致无法使用unique_ptr，因为会破环上面假设的“前一项拥有后一项”的前提
+    /*
+              +--- O ---+
+        O ---x           x--- nextO
+              +--- O ---+
+
+        会变成上面这样, 双向链表中用不到该操作所以直接注掉了。
+    */
+    // void insert(int val) {
+    //     auto node = std::make_unique<Node>(val);
+    //     node->next = next;
+    //     node->prev = prev;
+    //     if (prev)
+    //         prev->next = node;
+    //     if (next)
+    //         next->prev = node;
+    // }
 
     void erase() {
-        if (prev)
-            prev->next = next;
         if (next)
             next->prev = prev;
+        if (prev)
+            prev->next = std::move(next);
     }
 
     ~Node() {
-        printf("~Node()\n");   // 应输出多少次？为什么少了？
+        printf("~Node()\n");   // 应输出多少次？为什么少了？因为循环引用
     }
 };
 
+template<typename T>
 struct List {
-    std::shared_ptr<Node> head;
+    std::unique_ptr<Node<T>> head;
 
     List() = default;
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        head = std::make_unique<Node<T>>(other.head->value);
+        auto last = head.get();
+        for (auto ptr = other.head->next.get(); ptr; ptr = ptr->next.get()) {
+            auto node = std::make_unique<Node<T>>(ptr->value);
+            node->prev = last;
+            last->next = std::move(node);
+            last = last->next.get();
+        }
         // 请实现拷贝构造函数为 **深拷贝**
     }
 
     List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    // 此处拷贝赋值 = 拷贝构造出右值+移动赋值
 
     List(List &&) = default;
     List &operator=(List &&) = default;
 
-    Node *front() const {
+    Node<T> *front() const {
         return head.get();
     }
 
     int pop_front() {
         int ret = head->value;
-        head = head->next;
+        head = std::move(head->next);
         return ret;
     }
 
     void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
+        auto node = std::make_unique<Node<T>>(value);
         if (head)
-            head->prev = node;
-        head = node;
+            head->prev = node.get();
+        node->next = std::move(head);
+        head = std::move(node);
     }
 
-    Node *at(size_t index) const {
+    Node<T> *at(size_t index) const {
         auto curr = front();
         for (size_t i = 0; i < index; i++) {
             curr = curr->next.get();
@@ -80,7 +101,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(const List<int> &lst) {  // 有什么值得改进的？: 传入const引用，避免拷贝
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);
@@ -89,7 +110,7 @@ void print(List lst) {  // 有什么值得改进的？
 }
 
 int main() {
-    List a;
+    List<int> a;
 
     a.push_front(7);
     a.push_front(5);
@@ -105,7 +126,7 @@ int main() {
 
     print(a);   // [ 1 4 2 8 5 7 ]
 
-    List b = a;
+    List<int> b = a;
 
     a.at(3)->erase();
 


### PR DESCRIPTION
# 作业要求

- 避免函数参数不必要的拷贝 5 分
  - 在`print()`函数以及`push_front()`函数中可以将参数类型改为常量引用，避免拷贝
- 修复智能指针造成的问题 10 分
  - 对于双向链表，相邻项之间存在循环引用，引用计数无法归零释放空间。
  - 可以使用`unique_ptr` + `Node*`的方式解决
- 改用 `unique_ptr<Node>` 10 分
  - 对于双向链表，可以看作前一项“拥有”后一项。 而后一项保留前一项的Node*指针
  - List拥有一个`head`的`unique_ptr`
- 实现拷贝构造函数为深拷贝 15 分
  - 遍历等号右端List，逐项调用定义的`push_back(value_type const &)`函数即可
- 说明为什么可以删除拷贝赋值函数 5 分
  - 此处拷贝赋值 = 拷贝构造出右值+移动赋值
- 改进 `Node` 的构造函数 5 分
  - 构造value，而不是默认构造后再赋值。
  - 即把构造的部分放在冒号和花括号中间

# 改为模板

- 将`Node`, `List`均定义为模板
- 修改`value`为模板类型
- 修改`List`中成员函数的某些参数或返回值类型为对应的模板类型

# 迭代器

参考： [Prepare the custom iterator](https://www.internalpointers.com/post/writing-custom-iterators-modern-cpp)

第一次自定义迭代器，使用了`std::bidirectional_iterator_tag`，没有定义const_iterator。

```cpp
    class iterator {
    public:
        using iterator_category = std::bidirectional_iterator_tag;
        using difference_type   = std::ptrdiff_t;
        using value_type        = Node<T>;
        using pointer           = value_type*;  // or also value_type*
        using reference         = value_type&;  // or also value_type&

        iterator(pointer ptr): m_ptr(ptr) {}
        reference operator*() { return *m_ptr; }
        pointer operator->() { return m_ptr; }

        // Prefix increment
        iterator& operator++() 
        { m_ptr = m_ptr->next.get(); return *this; }  

        // Postfix increment
        iterator operator++(int) 
        { iterator tmp = *this; ++(*this); return tmp; }

        friend bool operator== (const iterator& a, const iterator& b) 
        { return a.m_ptr == b.m_ptr; };
        friend bool operator!= (const iterator& a, const iterator& b) 
        { return a.m_ptr != b.m_ptr; };     

    private:
        Node<T>* m_ptr;
    };
```