### PR TITLE
hw02 finshed

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,48 +4,57 @@
 
 struct Node {
     // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    std::unique_ptr<Node> next;
+    Node* prev;
     // 如果能改成 unique_ptr 就更好了!
 
     int value;
 
     // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
-    }
+    Node(int val):value(val), prev(nullptr){}
 
     void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
+        auto node = std::unique_ptr<Node>(new Node(val));
+        node->next = std::move(next);
         node->prev = prev;
         if (prev)
-            prev->next = node;
+            prev->next = std::move(node);
         if (next)
-            next->prev = node;
+            next->prev = node.get();
     }
 
     void erase() {
         if (prev)
-            prev->next = next;
+            prev->next = std::move(next);
         if (next)
             next->prev = prev;
     }
 
     ~Node() {
-        printf("~Node()\n");   // 应输出多少次？为什么少了？
+        printf("~Node()%d\n",value);   // 应输出多少次？为什么少了？
     }
 };
 
 struct List {
-    std::shared_ptr<Node> head;
+    std::unique_ptr<Node> head;
 
     List() = default;
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        //head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
+        auto othertmp = other.head.get();
+        if(other.head){
+            head = std::unique_ptr<Node>(new Node(other.head->value));
+            auto tmp = head.get();
+            while(othertmp->next){
+                tmp->next = std::unique_ptr<Node>(new Node(othertmp->next->value));
+                tmp->prev = tmp;
+                tmp = tmp->next.get();
+                othertmp = othertmp->next.get();
+            } 
+        }
     }
 
     List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
@@ -59,16 +68,16 @@ struct List {
 
     int pop_front() {
         int ret = head->value;
-        head = head->next;
+        head = std::move(head->next);
         return ret;
     }
 
     void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
+        auto node = std::unique_ptr<Node>(new Node(value));
         if (head)
-            head->prev = node;
-        head = node;
+            head->prev = node.get();
+        node->next = std::move(head);
+        head = std::move(node);
     }
 
     Node *at(size_t index) const {
@@ -80,7 +89,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(const List &lst) {  // 有什么值得改进的？
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);
@@ -92,6 +101,7 @@ int main() {
     List a;
 
     a.push_front(7);
+  //std::cout << a.head->value << std::endl;
     a.push_front(5);
     a.push_front(8);
     a.push_front(2);


### PR DESCRIPTION
因为拷贝赋值运算符已经删除，`v1 = v2`无法使用拷贝赋值运算符，但是存在移动赋值运算符，所以编译器尝试使用移动赋值运算符，把`v1 = v2`改造为`v1 = List(v2)`然后使用。因为List(v2)是临时对象，在本例中也是深拷贝所以不会影响原来的v2。