### PR TITLE
:pencil:unique_ptr & normal ptr

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,76 +2,101 @@
 #include <cstdio>
 #include <memory>
 
-struct Node {
+template<typename T>
+struct Node
+{
     // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    std::unique_ptr<Node<T>> next;
+    Node<T>*                 prev;
     // 如果能改成 unique_ptr 就更好了!
 
-    int value;
+    T value;
 
     // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
-    }
-
-    void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
-        node->prev = prev;
-        if (prev)
-            prev->next = node;
+    Node(T val) : next(nullptr), prev(nullptr), value(val)
+    {}
+    Node(T val, std::unique_ptr<Node<T>> next, Node<T>* prev)
+        : next(std::move(next)), prev(prev), value(val)
+    {
         if (next)
-            next->prev = node;
+            next->prev = this;
     }
 
-    void erase() {
-        if (prev)
-            prev->next = next;
+    void insert(T val)
+    {
+        prev->next = std::make_unique<Node<T>>(val, std::move(next), prev);
+    }
+
+    void erase()
+    {
         if (next)
             next->prev = prev;
+        if (prev)
+            prev->next = std::move(next);
     }
 
-    ~Node() {
+    ~Node()
+    {
         printf("~Node()\n");   // 应输出多少次？为什么少了？
     }
 };
 
-struct List {
-    std::shared_ptr<Node> head;
+template<typename T>
+struct List
+{
+    std::unique_ptr<Node<T>> head;
 
     List() = default;
 
-    List(List const &other) {
+    List(List<T> const& other)
+    {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        // head = other.head;   // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
+        auto* other_ptr = other.head.get();
+        auto* this_ptr  = head.get();
+        while (other_ptr) {
+            if (this_ptr) {
+                this_ptr->next = std::make_unique<Node<T>>(other_ptr->value, nullptr, this_ptr);
+                this_ptr       = this_ptr->next.get();
+            }
+            else {
+                head     = std::make_unique<Node<T>>(other_ptr->value, nullptr, nullptr);
+                this_ptr = head.get();
+            }
+            other_ptr = other_ptr->next.get();
+        }
     }
 
-    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    List& operator=(List const&) = delete;   // 为什么删除拷贝赋值函数也不出错？
 
-    List(List &&) = default;
-    List &operator=(List &&) = default;
+    List(List&&)  = default;
+    List& operator=(List&&) = default;
 
-    Node *front() const {
+    Node<T>* front() const
+    {
         return head.get();
     }
 
-    int pop_front() {
-        int ret = head->value;
-        head = head->next;
+    T pop_front()
+    {
+        T ret = head->value;
+        head  = std::move(head->next);
         return ret;
     }
 
-    void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
-        if (head)
-            head->prev = node;
-        head = node;
+    void push_front(T value)
+    {
+        auto node = std::make_unique<Node<T>>(value);
+        if (head) {
+            node->next       = std::move(head);
+            node->next->prev = node.get();
+        }
+        head = std::move(node);
     }
 
-    Node *at(size_t index) const {
+    Node<T>* at(size_t index) const
+    {
         auto curr = front();
         for (size_t i = 0; i < index; i++) {
             curr = curr->next.get();
@@ -80,16 +105,31 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+template<typename T>
+void print(const List<T>& lst);
+
+template<>
+void print(const List<int>& lst)
+{   // 有什么值得改进的？
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);
     }
     printf(" ]\n");
 }
+template<>
+void print(const List<char>& lst)
+{   // 有什么值得改进的？
+    printf("[");
+    for (auto curr = lst.front(); curr; curr = curr->next.get()) {
+        printf(" %c", curr->value);
+    }
+    printf(" ]\n");
+}
 
-int main() {
-    List a;
+int main()
+{
+    List<int> a;
 
     a.push_front(7);
     a.push_front(5);
@@ -105,15 +145,38 @@ int main() {
 
     print(a);   // [ 1 4 2 8 5 7 ]
 
-    List b = a;
+    List<int> b = a;
 
     a.at(3)->erase();
 
     print(a);   // [ 1 4 2 5 7 ]
     print(b);   // [ 1 4 2 8 5 7 ]
-
     b = {};
     a = {};
 
+    List<char> ac;
+
+    ac.push_front('7');
+    ac.push_front('5');
+    ac.push_front('8');
+    ac.push_front('2');
+    ac.push_front('9');
+    ac.push_front('4');
+    ac.push_front('1');
+
+    print(ac);   // [ 1 4 9 2 8 5 7 ]
+
+    ac.at(2)->erase();
+
+    print(ac);   // [ 1 4 2 8 5 7 ]
+
+    List<char> bc = ac;
+
+    ac.at(3)->erase();
+
+    print(ac);   // [ 1 4 2 5 7 ]
+    print(bc);   // [ 1 4 2 8 5 7 ]
+    bc = {};
+    ac = {};
     return 0;
 }


### PR DESCRIPTION
## 作业要求
- 避免函数参数不必要的拷贝  5 分
  - `void print(const &)`
- 修复智能指针造成的问题 10 分
  - shared_ptr互相指，导致`a={}`、`b={}`后链表无法释放
- 改用 `unique_ptr<Node>` 10 分
  - 改用unique_ptr<Node>和普通指针
- 实现拷贝构造函数为深拷贝 15 分
  - 构造一条一样的链表
- 说明为什么可以删除拷贝赋值函数 5 分
  - 在赋值时会调用拷贝构造函数，构造出一个临时对象，然后就可以移动赋值了
- 改进 `Node` 的构造函数 5 分
  - 增加了一个Node构造函数，允许将next和prev作为构造函数的参数

## 模板
- 将Node和List改为模板
- 为print函数添加 int 和 char 的特化