### PR TITLE
complete hw02 && 尝试支持了迭代器

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 GNUmakefile
+.cache

--- a/main.cpp
+++ b/main.cpp
@@ -6,16 +6,14 @@ struct Node {
     /*  Q: 这两个指针会造成什么问题？
         A: 产生了环形引用，导致无法解构。 */
     std::unique_ptr<Node> next;
-    struct Node* prev;
+    struct Node* prev = nullptr;
     // 如果能改成 unique_ptr 就更好了!
 
     int value;
 
     /*  Q: 这个构造函数有什么可以改进的？
         A: 添加 explicit 避免隐式转换。 */
-    explicit Node(int val) {
-        value = val;
-    }
+    explicit Node(int val) : value(val) {}
 
     void insert(int val) {
         auto node = std::make_unique<Node>(val);


### PR DESCRIPTION
- 避免函数参数不必要的拷贝 5 分
  - 修改为 ```void print(List &lst)```
- 修复智能指针造成的问题 10 分
- 改用 `unique_ptr<Node>` 10 分
  - 修改为使用```std::unique_ptr<Node> next;``` 和 ```struct Node* prev;```
  - 当链表的头节点被解构，会导致其next指针指向的节点被解构，直至整个链表的节点都被解构。
- 实现拷贝构造函数为深拷贝 15 分
  - 具体实现见代码。
- 说明为什么可以删除拷贝赋值函数 5 分
  - 因为这相当于使用拷贝构造函数就地构造出对象，从而进一步调用移动赋值函数完成整个过程。
  - 如果使用 ```explicit``` 关键词修饰拷贝构造函数，则会产生编译错误。
- 改进 `Node` 的构造函数 5 分
  - 使用 ```explicit``` 进行修饰。
  - 使用初始化表达式，避免重复初始化。

- 为了高效率的支持获取 ```end``` 迭代器，添加了一个位于链表尾部之后的尾指针。