### PR TITLE
finish hw02

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,54 +1,80 @@
 /* 基于智能指针实现双向链表 */
-#include <cstdio>
+// #include <cstdio>
+#include <iostream>
 #include <memory>
 
 struct Node {
-    // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    // 这两个指针会造成什么问题？请修复: 循环引用
+    // std::shared_ptr<Node> next;
+    // std::shared_ptr<Node> prev;
     // 如果能改成 unique_ptr 就更好了!
+    std::unique_ptr<Node> next;
+    Node* prev;
 
     int value;
 
     // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
+    // 1. 加入explicit修饰：避免发生隐式转换
+    // 2. 使用初始化列表来初始化成员变量：更规范，效率更高
+    explicit Node(int val): value(val) {
     }
 
     void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
+        auto node = std::make_unique<Node>(val);
+        if (next)
+            next->prev = node.get();   // 原始指针
+        node->next = std::move(next);  // next节点操作完成，转移控制权
         node->prev = prev;
         if (prev)
-            prev->next = node;
-        if (next)
-            next->prev = node;
+            prev->next = std::move(node); // node节点操作完成，转移控制权
     }
 
     void erase() {
-        if (prev)
-            prev->next = next;
         if (next)
             next->prev = prev;
+        if (prev)
+            prev->next = std::move(next);
     }
 
     ~Node() {
-        printf("~Node()\n");   // 应输出多少次？为什么少了？
+        std::cout<<"~Node()\n";   // 应输出多少次？为什么少了？应输出 x 次，x 为 Node 总数。循环引用导致 Node 无法正常解析
     }
 };
 
+template <typename T>
 struct List {
-    std::shared_ptr<Node> head;
+    // std::shared_ptr<Node> head;
+    // 链表的第一个节点，RAII
+    std::unique_ptr<Node> head;
 
     List() = default;
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        // head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
+        if (other.head == nullptr)
+            head = nullptr;
+        else {
+            head = std::make_unique<Node>(other.head->value);
+            auto curr = head.get();
+            auto other_next = other.head->next.get();
+            while (other_next != nullptr) {
+                auto new_node = std::make_unique<Node>(other_next->value);
+                new_node->prev = curr;
+                curr->next = std::move(new_node);
+                curr = curr->next.get();
+                other_next = other_next->next.get();
+            }
+        }
+        
     }
 
-    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    // 为什么删除拷贝赋值函数也不出错？
+    // 当用户调用v2 = v1时，因为拷贝赋值函数被删除，编译器会尝试：v2 = List(v1)
+    // 从而先调用拷贝构造函数，然后因为 List(v1) 相当于就地构造的对象(右值)，
+    // 从而变成了移动语义，从而进一步调用移动赋值函数
+    List &operator=(List const &) = delete;  
 
     List(List &&) = default;
     List &operator=(List &&) = default;
@@ -59,16 +85,16 @@ struct List {
 
     int pop_front() {
         int ret = head->value;
-        head = head->next;
+        head = std::move(head->next);
         return ret;
     }
 
     void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
+        auto node = std::make_unique<Node>(value);
         if (head)
-            head->prev = node;
-        head = node;
+            head->prev = node.get();
+        node->next = std::move(head);
+        head = std::move(node);
     }
 
     Node *at(size_t index) const {
@@ -80,16 +106,23 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
-    printf("[");
+// 有什么值得改进的？
+// 1.参数改为常量引用，避免不必要的拷贝
+// 2.printf需要指定数据类型，不通用，改为cout
+template <typename T>
+void print(const List<T>& lst) {  
+    // printf("[");
+    std::cout << "[";
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
-        printf(" %d", curr->value);
+        // printf(" %d", curr->value);
+        std::cout << ' ' << curr->value; 
     }
-    printf(" ]\n");
+    // printf(" ]\n");
+    std::cout << "]\n";
 }
 
 int main() {
-    List a;
+    List<int> a;
 
     a.push_front(7);
     a.push_front(5);
@@ -105,14 +138,16 @@ int main() {
 
     print(a);   // [ 1 4 2 8 5 7 ]
 
-    List b = a;
+    auto b = a;
 
     a.at(3)->erase();
 
     print(a);   // [ 1 4 2 5 7 ]
     print(b);   // [ 1 4 2 8 5 7 ]
 
+    std::cout << "empty list b:" << std::endl;
     b = {};
+    std::cout << "empty list a:" << std::endl;
     a = {};
 
     return 0;


### PR DESCRIPTION
1. 避免函数参数不必要的拷贝
修改print参数为const引用
2. 修复智能指针造成的问题 
修改Node成员变量next，prev的指针类型，避免循环引用问题
3. 改用 unique_ptr<Node>
同2
4. 实现拷贝构造函数为深拷贝
已修改List的拷贝构造函数
5. 说明为什么可以删除拷贝赋值函数 
当用户调用v2 = v1时，因为拷贝赋值函数被删除，编译器会尝试：v2 = List(v1)，从而先调用拷贝构造函数，
然后因为 List(v1) 相当于就地构造的对象(右值)，从而变成了移动语义，从而进一步调用移动赋值函数
6. 改进 Node 的构造函数
- 加入explicit修饰：避免发生隐式转换
- 使用初始化列表来初始化成员变量：更规范，效率更高