### PR TITLE
M cyclone

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,230 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Right
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: true
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Left
+AlignOperands:   AlignAfterOperator
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortLambdasOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: false
+BinPackParameters: false
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: true
+  BeforeWhile:     true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '<[[:alnum:].]+>'
+    Priority:        0
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+QualifierAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         true
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/main.cpp
+++ b/main.cpp
@@ -1,95 +1,122 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include <memory>
+#include <iostream>
 
-struct Node {
+template <typename T>
+struct Node
+{
     // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    std::unique_ptr<Node> next;
+    Node*                 prev;
     // 如果能改成 unique_ptr 就更好了!
 
-    int value;
+    T value;
 
     // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
-    }
+    explicit Node(T val) : value{ std::move(val) } {}
 
-    void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
+    void insert(T val)
+    {
+        auto node = std::make_unique<Node>(std::move(val));
+
         node->prev = prev;
-        if (prev)
-            prev->next = node;
-        if (next)
-            next->prev = node;
+        if (next) next->prev = node.get();
+
+        node->next = std::move(next);
+        if (prev) prev->next = std::move(node);
     }
 
-    void erase() {
-        if (prev)
-            prev->next = next;
-        if (next)
-            next->prev = prev;
+    void erase()
+    {
+        if (next) next->prev = prev;
+        if (prev) prev->next = std::move(next);
     }
 
-    ~Node() {
-        printf("~Node()\n");   // 应输出多少次？为什么少了？
+    ~Node()
+    {
+        printf("~Node()\n");  // 应输出多少次？为什么少了？
     }
 };
 
-struct List {
-    std::shared_ptr<Node> head;
+template <typename T>
+struct List
+{
+    std::unique_ptr<Node<T>> head;
 
     List() = default;
 
-    List(List const &other) {
+    List(const List& other)
+    {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        //head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
+
+        auto store = std::make_unique<Node<T>>(T{});
+        auto ptr   = other.front();
+        auto res   = store.get();
+
+        while (ptr)
+        {
+            auto node  = std::make_unique<Node<T>>(ptr->value);
+            node->prev = res->prev;
+            node->next = std::move(res->next);
+            res->next  = std::move(node);
+            res        = res->next.get();
+            ptr        = ptr->next.get();
+        }
+
+        head = std::move(store->next);
+        head->prev = nullptr;
     }
 
-    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    List& operator=(const List&) = delete;  // 为什么删除拷贝赋值函数也不出错？
 
-    List(List &&) = default;
-    List &operator=(List &&) = default;
+    List(List&&)            = default;
+    List& operator=(List&&) = default;
 
-    Node *front() const {
-        return head.get();
-    }
+    Node<T>* front() const { return head.get(); }
 
-    int pop_front() {
-        int ret = head->value;
-        head = head->next;
+    T pop_front()
+    {
+        T ret = std::move(head->value);
+        head  = std::move(head->next);
         return ret;
     }
 
-    void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
-        if (head)
-            head->prev = node;
-        head = node;
+    void push_front(T value)
+    {
+        auto node = std::make_unique<Node<T>>(std::move(value));
+        if (head) head->prev = node.get();
+        node->next = std::move(head);
+        head       = std::move(node);
     }
 
-    Node *at(size_t index) const {
+    Node<T>* at(size_t index) const
+    {
         auto curr = front();
-        for (size_t i = 0; i < index; i++) {
+        for (size_t i = 0; i < index && curr; i++)
+        {
             curr = curr->next.get();
         }
         return curr;
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
-    printf("[");
-    for (auto curr = lst.front(); curr; curr = curr->next.get()) {
-        printf(" %d", curr->value);
+template <typename T>
+void print(const List<T>& lst)
+{  // 有什么值得改进的？
+    std::cout << "[";
+    for (auto curr = lst.front(); curr; curr = curr->next.get())
+    {
+        std::cout << " " << curr->value;
     }
-    printf(" ]\n");
+    std::cout << " ]" << std::endl;
 }
 
-int main() {
-    List a;
+int main()
+{
+    List<int> a;
 
     a.push_front(7);
     a.push_front(5);
@@ -99,18 +126,18 @@ int main() {
     a.push_front(4);
     a.push_front(1);
 
-    print(a);   // [ 1 4 9 2 8 5 7 ]
+    print(a);  // [ 1 4 9 2 8 5 7 ]
 
     a.at(2)->erase();
 
-    print(a);   // [ 1 4 2 8 5 7 ]
+    print(a);  // [ 1 4 2 8 5 7 ]
 
     List b = a;
 
     a.at(3)->erase();
 
-    print(a);   // [ 1 4 2 5 7 ]
-    print(b);   // [ 1 4 2 8 5 7 ]
+    print(a);  // [ 1 4 2 5 7 ]
+    print(b);  // [ 1 4 2 8 5 7 ]
 
     b = {};
     a = {};

--- a/main.cpp
+++ b/main.cpp
@@ -8,7 +8,7 @@ struct Node
 {
     // 这两个指针会造成什么问题？请修复
     std::unique_ptr<Node> next;
-    Node*                 prev;
+    Node*                 prev = nullptr;
     // 如果能改成 unique_ptr 就更好了!
 
     T value;
@@ -18,7 +18,7 @@ struct Node
 
     void insert(T val)
     {
-        auto node = std::make_unique<Node>(std::move(val));
+        auto node = std::make_unique<Node<T>>(std::move(val));
 
         node->prev = prev;
         if (next) next->prev = node.get();


### PR DESCRIPTION
1. 将Node中next改为unique_ptr，prev改为裸指针，构造函数设为explicit并通过move的方式移动初始值进入；此外将insert和erase函数修改完成。
2. “~Node()”应该在两次erase时各输出一次，并在b析构时输出6次，a析构时输出5次。
3. 将List内head改为unique_ptr，并实现了深拷贝；此外完善了各函数，并为at函数补充了一点边界条件。
4. 用cout进行输出，适配模板下的List对象；此外将输入改为了const引用。