### PR TITLE
wyh hw02

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,29 +5,27 @@
 struct Node {
     // 这两个指针会造成什么问题？请修复
     std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    std::weak_ptr<Node> prev;
     // 如果能改成 unique_ptr 就更好了!
 
     int value;
 
-    // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
-    }
+    // 这个构造函数有什么可以改进的？ 
+    explicit Node(int val=0): value(val) { }
 
     void insert(int val) {
         auto node = std::make_shared<Node>(val);
         node->next = next;
         node->prev = prev;
-        if (prev)
-            prev->next = node;
+        if (!prev.expired())
+            prev.lock()->next = node;
         if (next)
             next->prev = node;
     }
 
     void erase() {
-        if (prev)
-            prev->next = next;
+        if (!prev.expired())
+            prev.lock()->next = next;
         if (next)
             next->prev = prev;
     }
@@ -43,12 +41,20 @@ struct List {
     List() = default;
 
     List(List const &other) {
-        printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+        printf("List be copied!\n");
+        // head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
+        head = std::make_shared<Node>(other.head->value);
+        auto now = head, othead = other.head;  //浅拷贝
+        while(othead->next){
+            now->next = std::make_shared<Node>(othead->next->value);
+            now->next->prev = now;
+            now = now->next, othead = othead->next;
+        }
     }
 
-    List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
+    List &operator=(List const &) = delete;  
+    // 为什么删除拷贝赋值函数也不出错？ 因为编译器默认使用析构函数+拷贝构造来代替拷贝赋值函数
 
     List(List &&) = default;
     List &operator=(List &&) = default;
@@ -80,7 +86,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(const List& lst) {  // 有什么值得改进的？传参const List&,减少拷贝并提高运行速度，减少运行时内存占用
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);


### PR DESCRIPTION
1.将prev改成shared_ptr<Node>类型,防止首尾指针互相指向，无法释放
2.给Node的构造函数添加explicit防止隐式构造，并且使用初始化列表减少一次赋值。
3.用两个指针实现深拷贝
4.为什么删除拷贝赋值函数也不出错？ 因为编译器默认使用析构函数+拷贝构造来代替拷贝赋值函数
5.print函数处：有什么值得改进的？传参const List&,减少拷贝并提高运行速度，减少运行时内存占用