### PR TITLE
using unique_ptr to avoid run-time cost

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,35 +1,38 @@
 /* 基于智能指针实现双向链表 */
 #include <cstdio>
 #include <memory>
+#include <utility>
 
 struct Node {
     // 这两个指针会造成什么问题？请修复
-    std::shared_ptr<Node> next;
-    std::shared_ptr<Node> prev;
+    std::unique_ptr<Node> next;
+    Node *prev{};
     // 如果能改成 unique_ptr 就更好了!
 
     int value;
 
     // 这个构造函数有什么可以改进的？
-    Node(int val) {
-        value = val;
+    explicit Node(int val):value(val) {
     }
 
     void insert(int val) {
-        auto node = std::make_shared<Node>(val);
-        node->next = next;
+        auto node = std::make_unique<Node>(val);
         node->prev = prev;
-        if (prev)
-            prev->next = node;
-        if (next)
-            next->prev = node;
+        if (next) {
+            next->prev = node.get();
+        }
+        node->next = std::move(next);
+        if (prev) {
+            prev->next = std::move(node);
+        }
     }
 
     void erase() {
-        if (prev)
-            prev->next = next;
         if (next)
             next->prev = prev;
+        if (prev) {
+            prev->next=std::move(next);
+        }
     }
 
     ~Node() {
@@ -38,14 +41,28 @@ struct Node {
 };
 
 struct List {
-    std::shared_ptr<Node> head;
+    std::unique_ptr<Node> head;
 
     List() = default;
 
     List(List const &other) {
         printf("List 被拷贝！\n");
-        head = other.head;  // 这是浅拷贝！
+//        head = other.head;  // 这是浅拷贝！
         // 请实现拷贝构造函数为 **深拷贝**
+        auto node = std::make_unique<Node>(other.head->value);
+        auto node_ptr=node.get();
+        head=std::move(node);
+
+        auto curr = other.head->next.get();
+        while(curr){
+            auto cur_node=std::make_unique<Node>(curr->value);
+            auto cur_node_ptr=cur_node.get();
+            cur_node->prev=node_ptr;
+            node_ptr->next=std::move(cur_node);
+            node_ptr=cur_node_ptr;
+
+            curr = curr->next.get();
+        }
     }
 
     List &operator=(List const &) = delete;  // 为什么删除拷贝赋值函数也不出错？
@@ -59,16 +76,16 @@ struct List {
 
     int pop_front() {
         int ret = head->value;
-        head = head->next;
+        head.reset(head->next.get());
         return ret;
     }
 
     void push_front(int value) {
-        auto node = std::make_shared<Node>(value);
-        node->next = head;
-        if (head)
-            head->prev = node;
-        head = node;
+        auto node = std::make_unique<Node>(value);
+        node->next = std::move(head);
+        if (node->next)
+            node->next->prev = node.get();
+        head=std::move(node);
     }
 
     Node *at(size_t index) const {
@@ -80,7 +97,7 @@ struct List {
     }
 };
 
-void print(List lst) {  // 有什么值得改进的？
+void print(const List &lst) {  // 有什么值得改进的？
     printf("[");
     for (auto curr = lst.front(); curr; curr = curr->next.get()) {
         printf(" %d", curr->value);

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
-cmake -B build
+cmake -B build -DCMAKE_BUILD_TYPE=False
 cmake --build build
 build/main


### PR DESCRIPTION
- 避免函数参数不必要的拷贝 5 分 。将print函数原先的传List的拷贝改为const List &。
- 修复智能指针造成的问题 10 分。使用unqie_ptr以及裸指针的组合避免循环引用造成的动态结点的内存无法释放。原始的Node的两个成员均为 shared_ptr，并且List的唯一成员head也为shared_ptr，当head不再指向链表的第一个结点时（即`a={}`执行时），由于链表的第二个结点仍指向第一个结点，导致第一个结点无法被释放，后续结点同理。而使用unique_ptr则独占结点内存。
- 改用 unique_ptr<Node> 10 分。上面已分析。
- 实现拷贝构造函数为深拷贝 15 分
- 说明为什么可以删除拷贝赋值函数 5 分。删除后，`a={}`仍能通过编译是因为右侧操作符被视作右值，从而调用了移动赋值函数。
- 改进 Node 的构造函数 5 分。加explicit关键字，以及使用列表初始化成员。